### PR TITLE
Update Spring Boot version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0-RC2</version>
+    <version>3.2.0</version>
     <relativePath />
   </parent>
   <groupId>com.bjoggis</groupId>


### PR DESCRIPTION
The version of Spring Boot in the pom.xml file was updated from 3.2.0-RC2 to the final release of 3.2.0. This keeps the project up-to-date with the latest stable version of Spring Boot.