### PR TITLE
Add status-checking and instance retrieval in Linode service

### DIFF
--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/in/CreateInstanceResponse.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/in/CreateInstanceResponse.java
@@ -1,5 +1,11 @@
 package com.bjoggis.linode.adapter.in;
 
-public record CreateInstanceResponse() {
+import com.bjoggis.linode.adapter.out.database.LinodeInstanceDbo;
 
+public record CreateInstanceResponse(Long linodeId, String label, String ip, String status) {
+
+  public static CreateInstanceResponse fromDbo(LinodeInstanceDbo dbo) {
+    return new CreateInstanceResponse(dbo.getLinodeId(), dbo.getLabel(), dbo.getIpv4(),
+        dbo.getStatus());
+  }
 }

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/in/GetInstanceResponse.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/in/GetInstanceResponse.java
@@ -1,0 +1,11 @@
+package com.bjoggis.linode.adapter.in;
+
+import com.bjoggis.linode.adapter.out.database.LinodeInstanceDbo;
+
+public record GetInstanceResponse(Long linodeId, String label, String ip, String status) {
+
+  public static GetInstanceResponse fromDbo(LinodeInstanceDbo dbo) {
+    return new GetInstanceResponse(dbo.getLinodeId(), dbo.getLabel(), dbo.getIpv4(),
+        dbo.getStatus());
+  }
+}

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/in/LinodeController.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/in/LinodeController.java
@@ -2,12 +2,18 @@ package com.bjoggis.linode.adapter.in;
 
 
 import com.bjoggis.linode.domain.LinodeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/v1/linode")
 @ResponseBody
+@RequestMapping("/v1/linode")
+@RestController
 public class LinodeController {
 
   private final LinodeService service;
@@ -17,8 +23,24 @@ public class LinodeController {
   }
 
   @PostMapping("/instance/create")
-  CreateInstanceResponse createInstance(CreateInstanceRequest request) {
-    return service.createInstance(request);
+  CreateInstanceResponse createInstance() {
+    return service.createInstance();
+  }
+
+  @GetMapping("/instance/{linodeId}")
+  ResponseEntity<GetInstanceResponse> getInstance(@PathVariable Long linodeId) {
+    GetInstanceResponse response = service.getLinodeInstanceById(linodeId);
+
+    if (response == null) {
+      return ResponseEntity.notFound().build();
+    }
+
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/instance/{linodeId}")
+  void deleteInstance(@PathVariable Long linodeId) {
+    service.deleteInstance(linodeId);
   }
 
 }

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/out/api/LinodeInterface.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/out/api/LinodeInterface.java
@@ -30,6 +30,10 @@ public interface LinodeInterface {
   @PostExchange("/v4/linode/instances")
   LinodeInstance create(@RequestBody CreateInstanceRequestBody instance);
 
+  @GetExchange("/v4/linode/instances/{linodeId}")
+  LinodeInstance getInstance(@PathVariable Long linodeId);
+
   @DeleteExchange("/v4/linode/instances/{linodeId}")
   void delete(@PathVariable Long linodeId);
+
 }

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeInstanceDboRepository.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeInstanceDboRepository.java
@@ -1,5 +1,6 @@
 package com.bjoggis.linode.adapter.out.database;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,10 @@ public interface LinodeInstanceDboRepository extends JpaRepository<LinodeInstanc
 
   @Query("select l from LinodeInstanceDbo l where l.linodeId = ?1 and l.deleted = false")
   Optional<LinodeInstanceDbo> findByLinodeIdAndNotDeleted(Long linodeId);
+
+  @Query("select l from LinodeInstanceDbo l where l.status != 'running' and l.deleted = false")
+  List<LinodeInstanceDbo> findAllWithStatusNotReady();
+
+  @Query("select l from LinodeInstanceDbo l where l.deleted = false")
+  List<LinodeInstanceDbo> findAllNotDeleted();
 }

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeRepository.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeRepository.java
@@ -1,6 +1,7 @@
 package com.bjoggis.linode.adapter.out.database;
 
 import com.bjoggis.linode.model.LinodeInstance;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,8 +15,13 @@ public interface LinodeRepository {
 
   Optional<LinodeInstanceDbo> findByLinodeId(Long id);
 
-  @Transactional(readOnly = true)
   Optional<LinodeInstanceDbo> findByLinodeIdAndNotDeleted(Long linodeId);
 
+  List<LinodeInstanceDbo> findAllWithStatusNotReady();
+
+  List<LinodeInstanceDbo> findAllNotDeleted();
+
   void setAsDeleted(Long id);
+
+  void updateStatus(Long id, String status);
 }

--- a/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeRepositoryImpl.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/adapter/out/database/LinodeRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.bjoggis.linode.adapter.out.database;
 import com.bjoggis.linode.model.LinodeInstance;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +56,16 @@ public class LinodeRepositoryImpl implements LinodeRepository {
   }
 
   @Override
+  public List<LinodeInstanceDbo> findAllWithStatusNotReady() {
+    return instanceRepository.findAllWithStatusNotReady();
+  }
+
+  @Override
+  public List<LinodeInstanceDbo> findAllNotDeleted() {
+    return instanceRepository.findAllNotDeleted();
+  }
+
+  @Override
   @Transactional
   public void setAsDeleted(Long id) {
     Optional<LinodeInstanceDbo> dbo = instanceRepository.findById(id);
@@ -63,6 +74,17 @@ public class LinodeRepositoryImpl implements LinodeRepository {
       LinodeInstanceDbo linodeInstanceDbo = dbo.get();
       linodeInstanceDbo.setDeleted(true);
       linodeInstanceDbo.setDeletedAt(new Date());
+      instanceRepository.save(linodeInstanceDbo);
+    }
+  }
+
+  @Override
+  public void updateStatus(Long id, String status) {
+    Optional<LinodeInstanceDbo> dbo = instanceRepository.findById(id);
+
+    if (dbo.isPresent()) {
+      LinodeInstanceDbo linodeInstanceDbo = dbo.get();
+      linodeInstanceDbo.setStatus(status);
       instanceRepository.save(linodeInstanceDbo);
     }
   }

--- a/linode4j/src/main/java/com/bjoggis/linode/configuration/LinodeConfiguration.java
+++ b/linode4j/src/main/java/com/bjoggis/linode/configuration/LinodeConfiguration.java
@@ -1,5 +1,6 @@
 package com.bjoggis.linode.configuration;
 
+import com.bjoggis.linode.adapter.in.LinodeController;
 import com.bjoggis.linode.adapter.out.api.LinodeInterface;
 import com.bjoggis.linode.adapter.out.database.LinodeInstanceDboRepository;
 import com.bjoggis.linode.adapter.out.database.LinodeRepository;
@@ -36,5 +37,10 @@ public class LinodeConfiguration {
   LinodeService linodeService(LinodeInterface linodeInterface,
       LinodeRepository linodeRepository) {
     return new LinodeService(linodeInterface, linodeRepository);
+  }
+
+  @Bean
+  LinodeController linodeController(LinodeService service) {
+    return new LinodeController(service);
   }
 }

--- a/mono/src/main/java/com/bjoggis/mono/BjoggisMonoApplication.java
+++ b/mono/src/main/java/com/bjoggis/mono/BjoggisMonoApplication.java
@@ -8,12 +8,14 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
 @EnableConfigurationProperties({OpenaiProperties.class, LinodeProperties.class})
 @EntityScan(basePackages = {"com.bjoggis.mono", "com.bjoggis.linode"})
 @EnableJpaRepositories(basePackages = {"com.bjoggis.mono", "com.bjoggis.linode"})
+@EnableScheduling
 public class BjoggisMonoApplication {
 
   public static void main(String[] args) {

--- a/mono/src/main/resources/application-prod.properties
+++ b/mono/src/main/resources/application-prod.properties
@@ -1,1 +1,3 @@
 spring.config.import=optional:configserver:http://config-server-service
+
+spring.jpa.show-sql=false


### PR DESCRIPTION
Added methods for frequently checking instance status and retrieving instance details in Linode service. Updates include scheduled methods to check status of instances not marked as ready and a method to get Linode instance by Id. Also added controller mappings for delete and getById operations, and implemented functionality to create a response from database objects.